### PR TITLE
Fix code scanning alert no. 25: Database query built from user-controlled sources

### DIFF
--- a/backend/Controllers/RecipeController.js
+++ b/backend/Controllers/RecipeController.js
@@ -308,7 +308,10 @@ const deleteRecipe = async (req, res) => {
    
 
     // If successful, delete the recipe from the database
-    await Recipe.deleteOne({ _id: req.body.id });
+    if (typeof req.body.id !== "string") {
+      return res.status(400).json({ success: false, message: "Invalid ID format" });
+    }
+    await Recipe.deleteOne({ _id: { $eq: req.body.id } });
 
     return res.status(200).json({ success: true, message: "Recipe Deleted Successfully" });
   } catch (error) {


### PR DESCRIPTION
Fixes [https://github.com/siddhbose-kivtechs/TastyTrails/security/code-scanning/25](https://github.com/siddhbose-kivtechs/TastyTrails/security/code-scanning/25)

To fix this issue, we need to ensure that the user-provided `id` is treated as a literal value and not as a query object. This can be achieved by using the `$eq` operator in the MongoDB query. Additionally, we should validate that `req.body.id` is a string to further mitigate the risk of injection attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
