### PR TITLE
Fix code scanning alert no. 24: Database query built from user-controlled sources

### DIFF
--- a/backend/Controllers/RecipeController.js
+++ b/backend/Controllers/RecipeController.js
@@ -242,7 +242,7 @@ const updateRecipe = async (req, res)=>{
  */
 const deleteRecipe = async (req, res) => {
   try {
-    const recipe = await Recipe.findById(req.body.id);
+    const recipe = await Recipe.findOne({ _id: { $eq: req.body.id } });
 
     if (!recipe) {
       return res.status(404).json({ success: false, message: "Recipe not found" });


### PR DESCRIPTION
Fixes [https://github.com/siddhbose-kivtechs/TastyTrails/security/code-scanning/24](https://github.com/siddhbose-kivtechs/TastyTrails/security/code-scanning/24)

To fix the problem, we need to ensure that the `req.body.id` is treated as a literal value and not as a query object. This can be achieved by using MongoDB's `$eq` operator to ensure that the user input is interpreted as a literal value. Alternatively, we can validate that `req.body.id` is a string before using it in the query.

The best way to fix this without changing existing functionality is to use the `$eq` operator in the query. This approach is straightforward and ensures that the input is treated as a literal value.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
