### PR TITLE
Fix code scanning alert no. 23: Database query built from user-controlled sources

### DIFF
--- a/backend/Controllers/RecipeController.js
+++ b/backend/Controllers/RecipeController.js
@@ -218,6 +218,9 @@ const getOneUserRecipes = async (req, res)=>{
 const updateRecipe = async (req, res)=>{
   try{ 
     const {name, description, ingredients, steps,type, user, author, id} = req.body
+        if (typeof id !== "string") {
+          return res.status(400).json({ success: false, message: "Invalid ID format" });
+        }
         const data = {
           user,
           name,
@@ -227,7 +230,7 @@ const updateRecipe = async (req, res)=>{
           author,
           type
         }
-        const update = await Recipe.updateOne({_id: id}, {$set: data}, {new:true})
+        const update = await Recipe.updateOne({_id: { $eq: id }}, {$set: data}, {new:true})
         return res.status(200).json({success: true, message: "Recipe Updates Successfully"})
   }catch(error){
     console.log(error);


### PR DESCRIPTION
Fixes [https://github.com/siddhbose-kivtechs/TastyTrails/security/code-scanning/23](https://github.com/siddhbose-kivtechs/TastyTrails/security/code-scanning/23)

To fix the problem, we need to ensure that the `id` used in the query is treated as a literal value and not as a query object. This can be achieved by using the `$eq` operator in the MongoDB query. Additionally, we should validate that the `id` is a string to further mitigate the risk of injection.

- Modify the query on line 230 to use the `$eq` operator.
- Add a check to ensure that `id` is a string before using it in the query.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
