### PR TITLE
Fix code scanning alert no. 17: Missing rate limiting

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -22,7 +22,8 @@
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.0.3",
     "nodemailer": "^6.9.15",
-    "prom-client": "^15.1.3"
+    "prom-client": "^15.1.3",
+    "express-rate-limit": "^7.4.1"
   },
   "devDependencies": {
     "nodemon": "^3.1.7"

--- a/backend/routes/web.js
+++ b/backend/routes/web.js
@@ -2,8 +2,15 @@ import { Router } from "express";
 import UserController from "../Controllers/UserController.js";
 import RecipeController from "../Controllers/RecipeController.js";
 import authenticateToken from "../middleware/auth.js";
+import rateLimit from 'express-rate-limit';
 
 const router = Router();
+
+// Set up rate limiter: maximum of 100 requests per 15 minutes
+const limiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
+});
 
 
 // Get Requests
@@ -16,12 +23,12 @@ router.get('/recipe/getcomments/:recipeId', RecipeController.getComments)
 // Post Requests
 router.post('/signup', UserController.Signup)
 router.post('/login', UserController.Login)
-router.post('/recipe/add', authenticateToken, RecipeController.addRecipe)
-router.post('/recipe/update', authenticateToken, RecipeController.updateRecipe)
-router.post('/recipe/readall', authenticateToken, RecipeController.getOneUserRecipes)
-router.post('/recipe/delete', authenticateToken, RecipeController.deleteRecipe)
+router.post('/recipe/add', authenticateToken, limiter, RecipeController.addRecipe)
+router.post('/recipe/update', authenticateToken, limiter, RecipeController.updateRecipe)
+router.post('/recipe/readall', authenticateToken, limiter, RecipeController.getOneUserRecipes)
+router.post('/recipe/delete', authenticateToken, limiter, RecipeController.deleteRecipe)
 // added route to add new comment to database
-router.post("/recipe/addcomment",authenticateToken, RecipeController.addComment)
+router.post("/recipe/addcomment", authenticateToken, limiter, RecipeController.addComment)
 router.post('/feedback', UserController.Sendcontactmail);
 
 export default router;


### PR DESCRIPTION
Fixes [https://github.com/siddhbose-kivtechs/TastyTrails/security/code-scanning/17](https://github.com/siddhbose-kivtechs/TastyTrails/security/code-scanning/17)

To fix the problem, we will introduce rate limiting to the Express application using the `express-rate-limit` package. This will help prevent denial-of-service attacks by limiting the number of requests a client can make to the server within a specified time window.

1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `backend/routes/web.js` file.
3. Set up a rate limiter with appropriate configuration (e.g., a maximum of 100 requests per 15 minutes).
4. Apply the rate limiter to the routes that perform expensive operations, such as database access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
